### PR TITLE
A proposal for adding creation of model serving containers using Github Actions

### DIFF
--- a/.github/workflows/build-runtime-classification.yaml
+++ b/.github/workflows/build-runtime-classification.yaml
@@ -1,0 +1,97 @@
+name: Build cpsign predict service for classification
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'v*.*.*'
+    tags:
+      - 'v*.*.*'
+    paths:
+      - '**'
+  pull_request:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'v*.*.*'
+    paths:
+      - '**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  build-model-runtimes:
+
+    runs-on: ubuntu-latest
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: 'classification'
+      #DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      #DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_FILE: 'Dockerfile.classification'
+      working-directory: .
+      WAR_VERSION: '2.0.0-SNAPSHOT'
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # https://github.com/docker/setup-qemu-action
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    #- name: docker login
+    #  run: |
+    #    docker login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GH_TOKEN }}
+
+    - name: Login to GHCR
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        #username: ${{ github.actor }}
+        #password: ${{ secrets.GH_TOKEN }}
+
+    - name: Docker meta
+      id: meta_predictionservice
+      uses: docker/metadata-action@v3
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          ghcr.io/arosbio/classification
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.working-directory}}
+        platforms: linux/amd64,linux/arm64
+        file: ${{env.DOCKER_FILE}}
+        #,linux/arm/v8
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta_predictionservice.outputs.tags }}
+        labels: ${{ steps.meta_predictionservice.outputs.labels }}
+        build-args: |
+          BASE=ghcr.io/arosbio/predictionservice:latest
+          WAR_FILE=cp_classification-${{ env.WAR_VERSION }}.war
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/build-runtime-regression.yaml
+++ b/.github/workflows/build-runtime-regression.yaml
@@ -1,0 +1,96 @@
+name: Build cpsign predict service for regression
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'v*.*.*'
+    tags:
+      - 'v*.*.*'
+    paths:
+      - '**'
+  pull_request:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'v*.*.*'
+    paths:
+      - '**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  build-model-runtimes:
+
+    runs-on: ubuntu-latest
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: 'regression'
+      #DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      #DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_FILE: 'Dockerfile.regression'
+      working-directory: .
+      WAR_VERSION: '2.0.0-SNAPSHOT'
+    steps:
+    - uses: actions/checkout@v2
+
+    # https://github.com/docker/setup-qemu-action
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    #- name: docker login
+    #  run: |
+    #    docker login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GH_TOKEN }}
+
+    - name: Login to GHCR
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        #username: ${{ github.actor }}
+        #password: ${{ secrets.GH_TOKEN }}
+
+    - name: Docker meta
+      id: meta_predictionservice
+      uses: docker/metadata-action@v3
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          ghcr.io/arosbio/regression
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.working-directory}}
+        platforms: linux/amd64,linux/arm64
+        file: ${{env.DOCKER_FILE}}
+        #,linux/arm/v8
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta_predictionservice.outputs.tags }}
+        labels: ${{ steps.meta_predictionservice.outputs.labels }}
+        build-args: |
+          BASE=ghcr.io/arosbio/predictionservice:latest
+          WAR_FILE=cp_regression-${{ env.WAR_VERSION }}.war
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/build-runtime.yaml
+++ b/.github/workflows/build-runtime.yaml
@@ -1,0 +1,93 @@
+name: Build cpsign prediction service
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'v*.*.*'
+    tags:
+      - 'v*.*.*'
+    paths:
+      - '**'
+  pull_request:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'v*.*.*'
+    paths:
+      - '**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  build-model-runtimes:
+
+    runs-on: ubuntu-latest
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: 'predictionservice'
+      #DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      #DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_FILE: 'Dockerfile'
+      working-directory: .
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # https://github.com/docker/setup-qemu-action
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    #- name: docker login
+    #  run: |
+    #    docker login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GH_TOKEN }}
+
+    - name: Login to GHCR
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        #username: ${{ github.actor }}
+        #password: ${{ secrets.GH_TOKEN }}
+
+    - name: Docker meta
+      id: meta_predictionservice
+      uses: docker/metadata-action@v3
+      with:
+        # list of Docker images to use as base name for tags
+        images: |
+          ghcr.io/arosbio/predictionservice
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.working-directory}}
+        platforms: linux/amd64,linux/arm64
+        file: ${{env.DOCKER_FILE}}
+        #,linux/arm/v8
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta_predictionservice.outputs.tags }}
+        labels: ${{ steps.meta_predictionservice.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:20.04 as basebuilder
+ENV TZ=Europe/Stockholm
+ENV DEBUG='True'
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN /bin/bash -c "apt-get update && apt-get install openjdk-11-jdk-headless maven python3-pip nginx -y"
+
+COPY . /app
+RUN /bin/bash -c "cd /app && /usr/bin/mvn clean -Dmaven.test.skip=true package && cd .."

--- a/Dockerfile.classification
+++ b/Dockerfile.classification
@@ -1,0 +1,11 @@
+ARG BASE
+ARG WAR_FILE=cp_classification-2.0.0-SNAPSHOT.war
+
+FROM $BASE as builder
+
+#FROM jetty:9-jdk11
+FROM jetty:11.0.14-jre17
+# generalize this here and perhaps set this as an argument or env variable
+COPY --from=builder /app/cp_classification/target/${WAR_FILE} /var/lib/jetty/webapps/ROOT.war
+
+RUN mkdir /var/lib/jetty/models/

--- a/Dockerfile.regression
+++ b/Dockerfile.regression
@@ -1,0 +1,10 @@
+ARG BASE
+ARG WAR_FILE=cp_regression-2.0.0-SNAPSHOT.war
+FROM $BASE as builder
+
+#FROM jetty:9-jdk11
+FROM jetty:11.0.14-jre17
+# generalize this here and perhaps set this as an argument or env variable
+COPY --from=builder /app/cp_classification/target/${WAR_FILE} /var/lib/jetty/webapps/ROOT.war
+
+RUN mkdir /var/lib/jetty/models/

--- a/docker_example/Dockerfile
+++ b/docker_example/Dockerfile
@@ -1,7 +1,7 @@
-FROM jetty:11.0.14-jre17
+FROM ghcr.io/arosbio/predictservice:latest
 
-# Copy the service application
-COPY ROOT.war /var/lib/jetty/webapps/ROOT.war
 
 # Copy the model to the default location
-COPY test-model.cpsign /var/lib/jetty/model.jar
+COPY YOUR-MODEL.cpsign /var/lib/jetty/model.jar
+# tell the service where to find the model
+ENV MODEL_FILE=/var/lib/jetty/model.jar


### PR DESCRIPTION
# Multi stage build.
1. Creation of predictservice runtime ( by building war files).
2. Copying the correct war file for regression or classification creating serving containers specifically for running this ROOT.war in jetty.
3. Updated example to use this runtime.

## Prereqs
it requires some ocnfiguration to get Github Actions working including adding permissions to for GA to write to packages for it to upload to ghcr.io/

## First time the regression/classification run it will fail as the default predictservice:latest base image is not available.

@StaffanArvidsson  please also check the "2.0.0-SNAPSHOT" variable. i didnt know where this will come from but it most likely needs to be taken from somewhere in the ENV or such.
